### PR TITLE
refactor(common): update k8s network api version

### DIFF
--- a/roles/v1alpha1/common/tasks/common/ingress-wait.yml
+++ b/roles/v1alpha1/common/tasks/common/ingress-wait.yml
@@ -4,7 +4,7 @@
   retries: 6
   delay: 30
   k8s_info:
-    api_version: networking.k8s.io/v1beta1
+    api_version: networking.k8s.io/v1
     kind: Ingress
     namespace: "{{ meta_namespace }}"
     name: "{{ metadata_name }}"

--- a/roles/v1alpha1/common/templates/common/ingress.yaml.j2
+++ b/roles/v1alpha1/common/templates/common/ingress.yaml.j2
@@ -1,7 +1,7 @@
 # {{ name }} ingress
 ---
 kind: Ingress
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {% include common_path + '/metadata.j2' ignore missing %}
 {% if ingress_spec != false %}
 spec:


### PR DESCRIPTION
v1 is available since k8s v1.19.
v1beta1 will not be available in k8s v1.22