### PR TITLE
fix: use a block string for node selector and affinity

### DIFF
--- a/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
+++ b/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
@@ -153,11 +153,11 @@ template:
 {% endif %}
 {% if keydb_node_selector %}
     nodeSelector:
-      {{ keydb_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ keydb_node_selector | indent(6) }}
 {% endif %}
 {% if keydb_affinity %}
     affinity:
-      {{ keydb_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ keydb_affinity | indent(6) }}
 {% endif %}
 volumeClaimTemplates:
   {{ keydb_volume_claim_template | to_nice_yaml(indent=2) | indent(2) }}

--- a/roles/v1alpha1/database/postgres/templates/deploy/pgbouncer-readonly-spec.yaml.j2
+++ b/roles/v1alpha1/database/postgres/templates/deploy/pgbouncer-readonly-spec.yaml.j2
@@ -173,9 +173,9 @@ template:
 {% endif %}
 {% if pgbouncer_readonly_node_selector %}
     nodeSelector:
-      {{ pgbouncer_readonly_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ pgbouncer_readonly_node_selector | indent(6) }}
 {% endif %}
 {% if pgbouncer_readonly_affinity %}
     affinity:
-      {{ pgbouncer_readonly_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ pgbouncer_readonly_affinity | indent(6) }}
 {% endif %}

--- a/roles/v1alpha1/database/postgres/templates/deploy/pgbouncer-spec.yaml.j2
+++ b/roles/v1alpha1/database/postgres/templates/deploy/pgbouncer-spec.yaml.j2
@@ -173,9 +173,9 @@ template:
 {% endif %}
 {% if pgbouncer_node_selector %}
     nodeSelector:
-      {{ pgbouncer_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ pgbouncer_node_selector | indent(6) }}
 {% endif %}
 {% if pgbouncer_affinity %}
     affinity:
-      {{ pgbouncer_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ pgbouncer_affinity | indent(6) }}
 {% endif %}

--- a/roles/v1alpha1/database/postgres/templates/sts/postgres-spec.yaml.j2
+++ b/roles/v1alpha1/database/postgres/templates/sts/postgres-spec.yaml.j2
@@ -203,11 +203,11 @@ template:
 {% endif %}
 {% if postgres_node_selector %}
     nodeSelector:
-      {{ postgres_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ postgres_node_selector | indent(6) }}
 {% endif %}
 {% if postgres_affinity %}
     affinity:
-      {{ postgres_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ postgres_affinity | indent(6) }}
 {% endif %}
 volumeClaimTemplates:
   {{ postgres_volume_claim_template | to_nice_yaml(indent=2) | indent(2) }}

--- a/roles/v1alpha1/database/postgres/templates/sts/readreplicas-spec.yaml.j2
+++ b/roles/v1alpha1/database/postgres/templates/sts/readreplicas-spec.yaml.j2
@@ -203,11 +203,11 @@ template:
 {% endif %}
 {% if postgres_readreplicas_node_selector %}
     nodeSelector:
-      {{ postgres_readreplicas_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ postgres_readreplicas_node_selector | indent(6) }}
 {% endif %}
 {% if postgres_readreplicas_affinity %}
     affinity:
-      {{ postgres_readreplicas_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ postgres_readreplicas_affinity | indent(6) }}
 {% endif %}
 volumeClaimTemplates:
   {{ postgres_readreplicas_volume_claim_template | to_nice_yaml(indent=2) | indent(2) }}

--- a/roles/v1alpha1/m4e/moodle/templates/cronjob/moodle-spec.yaml.j2
+++ b/roles/v1alpha1/m4e/moodle/templates/cronjob/moodle-spec.yaml.j2
@@ -121,9 +121,9 @@ jobTemplate:
 {% endif %}
 {% if moodle_cronjob_node_selector %}
         nodeSelector:
-          {{ moodle_cronjob_node_selector | to_nice_yaml(indent=2) | indent(10) }}
+          {{ moodle_cronjob_node_selector | indent(10) }}
 {% endif %}
 {% if moodle_cronjob_affinity %}
         affinity:
-          {{ moodle_cronjob_affinity | to_nice_yaml(indent=2) | indent(10) }}
+          {{ moodle_cronjob_affinity | indent(10) }}
 {% endif %}

--- a/roles/v1alpha1/m4e/moodle/templates/job/moodle-new-instance-spec.yaml.j2
+++ b/roles/v1alpha1/m4e/moodle/templates/job/moodle-new-instance-spec.yaml.j2
@@ -129,9 +129,9 @@ template:
 {% endif %}
 {% if moodle_new_instance_job_node_selector %}
     nodeSelector:
-      {{ moodle_new_instance_job_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ moodle_new_instance_job_node_selector | indent(6) }}
 {% endif %}
 {% if moodle_new_instance_job_affinity %}
     affinity:
-      {{ moodle_new_instance_job_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ moodle_new_instance_job_affinity | indent(6) }}
 {% endif %}

--- a/roles/v1alpha1/m4e/moodle/templates/job/moodle-update-spec.yaml.j2
+++ b/roles/v1alpha1/m4e/moodle/templates/job/moodle-update-spec.yaml.j2
@@ -122,9 +122,9 @@ template:
 {% endif %}
 {% if moodle_update_job_node_selector %}
     nodeSelector:
-      {{ moodle_update_job_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ moodle_update_job_node_selector | indent(6) }}
 {% endif %}
 {% if moodle_update_job_affinity %}
     affinity:
-      {{ moodle_update_job_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ moodle_update_job_affinity | indent(6) }}
 {% endif %}

--- a/roles/v1alpha1/nfs/ganesha/templates/sts/ganesha-spec.yaml.j2
+++ b/roles/v1alpha1/nfs/ganesha/templates/sts/ganesha-spec.yaml.j2
@@ -307,11 +307,11 @@ template:
 {% endif %}
 {% if ganesha_node_selector %}
     nodeSelector:
-      {{ ganesha_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ ganesha_node_selector | indent(6) }}
 {% endif %}
 {% if ganesha_affinity %}
     affinity:
-      {{ ganesha_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ ganesha_affinity | indent(6) }}
 {% endif %}
 volumeClaimTemplates:
   {{ ganesha_volume_claim_template | to_nice_yaml(indent=2) | indent(2) }}

--- a/roles/v1alpha1/web/nginx/templates/deploy/nginx-spec.yaml.j2
+++ b/roles/v1alpha1/web/nginx/templates/deploy/nginx-spec.yaml.j2
@@ -186,9 +186,9 @@ template:
 {% endif %}
 {% if nginx_node_selector %}
     nodeSelector:
-      {{ nginx_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ nginx_node_selector | indent(6) }}
 {% endif %}
 {% if nginx_affinity %}
     affinity:
-      {{ nginx_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ nginx_affinity | indent(6) }}
 {% endif %}

--- a/roles/v1alpha1/web/php_fpm/templates/deploy/php-fpm-spec.yaml.j2
+++ b/roles/v1alpha1/web/php_fpm/templates/deploy/php-fpm-spec.yaml.j2
@@ -197,9 +197,9 @@ template:
 {% endif %}
 {% if php_fpm_node_selector %}
     nodeSelector:
-      {{ php_fpm_node_selector | to_nice_yaml(indent=2) | indent(6) }}
+      {{ php_fpm_node_selector | indent(6) }}
 {% endif %}
 {% if php_fpm_affinity %}
     affinity:
-      {{ php_fpm_affinity | to_nice_yaml(indent=2) | indent(6) }}
+      {{ php_fpm_affinity | indent(6) }}
 {% endif %}


### PR DESCRIPTION
operator sdk trasnform fields from camelCase