### PR TITLE
Allowing for KeyDB statefulsets using an emptyDir volume

### DIFF
--- a/roles/v1alpha1/database/keydb/defaults/main/keydb.yml
+++ b/roles/v1alpha1/database/keydb/defaults/main/keydb.yml
@@ -82,6 +82,7 @@ keydb_service_headless_spec: |
   {% endif %}
 
 # keydb pvc
+keydb_pvc_enabled: true
 keydb_pvc_data: "{{ keydb_appname }}-data-pvc"
 keydb_pvc_data_storage_access_mode: ReadWriteOnce
 keydb_pvc_data_storage_class_name: false

--- a/roles/v1alpha1/database/keydb/defaults/main/keydb.yml
+++ b/roles/v1alpha1/database/keydb/defaults/main/keydb.yml
@@ -81,6 +81,10 @@ keydb_service_headless_spec: |
       timeoutSeconds: {{ keydb_service_session_affinity_timeout }}
   {% endif %}
 
+# keydb empty dir
+keydb_empty_dir_data: |-
+  medium: Memory
+
 # keydb pvc
 keydb_pvc_enabled: true
 keydb_pvc_data: "{{ keydb_appname }}-data-pvc"

--- a/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
+++ b/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
@@ -133,8 +133,13 @@ template:
       - mountPath: /etc/keydb/keydb.conf
         name: keydb-config
         subPath: keydb.conf
+{% if keydb_pvc_enabled %}
       - mountPath: '{{ keydb_data }}'
         name: {{ keydb_pvc_data }}
+{% else %}
+      - mountPath: '{{ keydb_data }}'
+        name: data
+{% endif %}
     volumes:
     - name: keydb-config
       configMap:
@@ -143,6 +148,11 @@ template:
         items:
         - key: keydb.conf
           path: keydb.conf
+{% if not keydb_pvc_enabled %}
+    - name: data
+      emptyDir:
+        medium: Memory
+{% endif %}
 {% if keydb_tolerations is defined and keydb_tolerations %}
     tolerations:
     {{ keydb_tolerations | to_nice_yaml(indent=2) | indent(4) }}
@@ -159,5 +169,7 @@ template:
     affinity:
       {{ keydb_affinity | indent(6) }}
 {% endif %}
+{% if keydb_pvc_enabled %}
 volumeClaimTemplates:
   {{ keydb_volume_claim_template | to_nice_yaml(indent=2) | indent(2) }}
+{% endif %}

--- a/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
+++ b/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
@@ -133,12 +133,12 @@ template:
       - mountPath: /etc/keydb/keydb.conf
         name: keydb-config
         subPath: keydb.conf
-{% if keydb_pvc_enabled %}
+{% if keydb_pvc_enabled | bool %}
       - mountPath: '{{ keydb_data }}'
         name: {{ keydb_pvc_data }}
 {% else %}
       - mountPath: '{{ keydb_data }}'
-        name: data
+        name: keydb-data
 {% endif %}
     volumes:
     - name: keydb-config
@@ -148,10 +148,10 @@ template:
         items:
         - key: keydb.conf
           path: keydb.conf
-{% if not keydb_pvc_enabled %}
-    - name: data
+{% if not keydb_pvc_enabled | bool %}
+    - name: keydb-data
       emptyDir:
-        medium: Memory
+        {{ keydb_empty_dir_data | indent(8) }}
 {% endif %}
 {% if keydb_tolerations is defined and keydb_tolerations %}
     tolerations:
@@ -169,7 +169,7 @@ template:
     affinity:
       {{ keydb_affinity | indent(6) }}
 {% endif %}
-{% if keydb_pvc_enabled %}
+{% if keydb_pvc_enabled | bool %}
 volumeClaimTemplates:
   {{ keydb_volume_claim_template | to_nice_yaml(indent=2) | indent(2) }}
 {% endif %}


### PR DESCRIPTION
This PR contains changes to the templates that allow configuring KeyDB statefulsets to use an emptyDir volume rather than persistent storage.