### PR TITLE
Removing the initContainer when pvc is disabled

### DIFF
--- a/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
+++ b/roles/v1alpha1/database/keydb/templates/sts/keydb-spec.yaml.j2
@@ -14,7 +14,7 @@ template:
       sysctls:
       {{ keydb_sysctls | to_nice_yaml(indent=2) | indent(6) }}
 {% endif %}
-{% if k8s_distribution == 'k8s' %}
+{% if k8s_distribution == 'k8s' and keydb_pvc_enabled | bool %}
     initContainers:
     - name: 'data-dir-permissions'
       image: '{{ keydb_image }}'


### PR DESCRIPTION
When the pvc is disabled, the initContainer is not required, and breaks the sts because it refers to the non-existent PVC.